### PR TITLE
Fix timezone handling in iCal event export

### DIFF
--- a/server/api/classes.ts
+++ b/server/api/classes.ts
@@ -49,20 +49,15 @@ export default defineEventHandler(async (event) => {
             )
           );
 
-          const startTime = DateTime.fromISO(subEventDetails[0].startTime)
-            .setZone("Europe/Berlin")
-            .toJSDate();
-          console.log("startTime", subEventDetails[0].startTime, startTime);
-
           // Add each sub-event to the calendar
           subEventDetails.forEach((detailedSubEvent) => {
             const eventDetails: ICalEventData = {
-              start: DateTime.fromISO(detailedSubEvent.startTime)
-                .setZone("Europe/Berlin")
-                .toJSDate(),
-              end: DateTime.fromISO(detailedSubEvent.endTime)
-                .setZone("Europe/Berlin")
-                .toJSDate(),
+              start: DateTime.fromISO(detailedSubEvent.startTime).setZone(
+                "Europe/Berlin"
+              ),
+              end: DateTime.fromISO(detailedSubEvent.endTime).setZone(
+                "Europe/Berlin"
+              ),
               summary: eventData.name,
               description: `Dozent: ${eventData.lecturerNames}`,
               location: detailedSubEvent.rooms,


### PR DESCRIPTION
**Description:**
This MR corrects the timezone handling for events in the iCal file download. Previously, the `toJSDate` conversion was applied, but it has now been removed to ensure proper timezone representation.

**Changes:**
- Removed unnecessary `.toJSDate()` calls  for `start` and `end` properties of `eventDetails`.

**Impact:**
This change ensures that the iCal files generated for event exports have the correct timezone information applied, specifically for the `Europe/Berlin` time zone, leading to accurate scheduling when imported into calendar applications.

**Testing:**
- Verified that the start and end times in the downloaded iCal file correctly reflect the `Europe/Berlin` time zone.