### PR TITLE
fix: remove `All` option from items per page selector and add custom …

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -104,6 +104,7 @@
           item-value="id"
           :items-length="events.state.value?.headers?.totalNumberOfResults ?? 0"
           v-model:items-per-page="itemsPerPage"
+          :items-per-page-options="itemsPerPageOptions"
           :loading="events.isLoading.value"
           @update:options="loadItems"
           class="mt-8"
@@ -208,6 +209,7 @@ import { z } from "zod";
 const selectedEvents = reactive(new Map<number, Event>());
 const search = ref("");
 const itemsPerPage = ref(10);
+const itemsPerPageOptions = [5, 10, 15, 20];
 
 // Table headers
 const headers: VDataTable["$props"]["headers"] = [


### PR DESCRIPTION
Removed the `All` option because the back-end doesn't support it and added smaller items-per-page options (5, 10, 15, 20) for a better overview.